### PR TITLE
Clean up on node close

### DIFF
--- a/nodes/docker.js
+++ b/nodes/docker.js
@@ -56,6 +56,10 @@ module.exports = function(RED) {
                 this.status({fill:'yellow',shape:'ring',text:'stream ended'});
                 this.warn('Docker event stream ended.')
             })
+            
+            this.on('close', function() {
+               events.destroy()
+            })
         })
     }
 


### PR DESCRIPTION
Make sure that the stream is stopped when the node is closed (https://nodered.org/docs/creating-nodes/node-js#closing-the-node) otherwise the stream will keep doing this.send() even if the node has been closed (e.g. when re-deployed).